### PR TITLE
Add presto dependency to presto-shaded module

### DIFF
--- a/rubix-presto-shaded/pom.xml
+++ b/rubix-presto-shaded/pom.xml
@@ -35,6 +35,10 @@
             <groupId>com.qubole.rubix</groupId>
             <artifactId>rubix-prestosql</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.qubole.rubix</groupId>
+            <artifactId>rubix-presto</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -64,6 +68,7 @@
                                     <include>com.qubole.rubix:rubix-bookkeeper</include>
                                     <include>com.qubole.rubix:rubix-hadoop2</include>
                                     <include>com.qubole.rubix:rubix-prestosql</include>
+                                    <include>com.qubole.rubix:rubix-presto</include>
                                 </includes>
                             </artifactSet>
                             <relocations>


### PR DESCRIPTION
This is needed to enable Rubix caching support for presto. Right now Rubix shaded jar which is being pulled from the maven central repo doesn't include dependency from the 'rubix-presto' module.